### PR TITLE
create fakepkgs from maxton

### DIFF
--- a/PkgEditor/MainWin.Designer.cs
+++ b/PkgEditor/MainWin.Designer.cs
@@ -48,6 +48,7 @@
       this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
       this.aboutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
       this.setPKGPFSFileMetadataToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.createACFKPGsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
       this.menuStrip.SuspendLayout();
       this.SuspendLayout();
       // 
@@ -157,7 +158,8 @@
       this.toolsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.combinePKGPartsToolStripMenuItem,
             this.cryptoDebuggerToolStripMenuItem,
-            this.setPKGPFSFileMetadataToolStripMenuItem});
+            this.setPKGPFSFileMetadataToolStripMenuItem,
+            this.createACFKPGsToolStripMenuItem});
       this.toolsToolStripMenuItem.Name = "toolsToolStripMenuItem";
       this.toolsToolStripMenuItem.Size = new System.Drawing.Size(46, 20);
       this.toolsToolStripMenuItem.Text = "&Tools";
@@ -204,6 +206,13 @@
       this.aboutToolStripMenuItem.Size = new System.Drawing.Size(167, 22);
       this.aboutToolStripMenuItem.Text = "&About...";
       this.aboutToolStripMenuItem.Click += new System.EventHandler(this.aboutToolStripMenuItem_Click);
+      // 
+      // createACFKPGsToolStripMenuItem
+      // 
+      this.createACFKPGsToolStripMenuItem.Name = "createACFKPGsToolStripMenuItem";
+      this.createACFKPGsToolStripMenuItem.Size = new System.Drawing.Size(210, 22);
+      this.createACFKPGsToolStripMenuItem.Text = "Create AC FKPGs";
+      this.createACFKPGsToolStripMenuItem.Click += new System.EventHandler(this.createACFKPGsToolStripMenuItem_Click);
       // 
       // setPKGPFSFileMetadataToolStripMenuItem
       // 
@@ -255,6 +264,7 @@
     private System.Windows.Forms.ToolStripMenuItem visitGitHubRepoToolStripMenuItem;
     private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
     private System.Windows.Forms.ToolStripMenuItem setPKGPFSFileMetadataToolStripMenuItem;
+    private System.Windows.Forms.ToolStripMenuItem createACFKPGsToolStripMenuItem;
   }
 }
 


### PR DESCRIPTION
This adds the ability to create ac fpkgs. this was taken from a built binary recovered from an archived channel that was built by maxton himself. creating an ac fpkg allows you to unlock and dump ac with additional data files on real console without needing entitlements for the ac. you must still have entitlements for the base game

install fpkg, install real encrypted dlc, launch game with entitlement, dlc will be mounted and able to be dumped