### PR TITLE
fix: nested directories in sce_sys are now counted as entries

### DIFF
--- a/LibOrbisPkg/PFS/PFSBuilder.cs
+++ b/LibOrbisPkg/PFS/PFSBuilder.cs
@@ -97,7 +97,22 @@ namespace LibOrbisPkg.PFS
 
       Log("Setting up filesystem structure...");
       allDirs = properties.root.GetAllChildrenDirs();
-      allFiles = properties.root.GetAllChildrenFiles().Where(f => f.Parent?.name != "sce_sys" || !PKG.EntryNames.NameToId.ContainsKey(f.name)).ToList();
+      allFiles = properties.root.GetAllChildrenFiles().Where((f) => {
+        bool is_sce_sys = false;
+        var name = f.name;
+        var parent = f.Parent;
+        while (parent != null && parent != properties.root)
+        {
+          if (parent.Parent == properties.root && parent.name == "sce_sys")
+          {
+            is_sce_sys = true;
+            break;
+          }
+          name = parent.name + "/" + name;
+          parent = parent.Parent;
+        }
+        return !is_sce_sys || !PKG.EntryNames.NameToId.ContainsKey(name);
+      }).ToList();
       allNodes = new List<FSNode>(allDirs.OrderBy(d => d.FullPath()).ToList());
       allNodes.AddRange(allFiles);
 

--- a/LibOrbisPkg/PKG/PkgBuilder.cs
+++ b/LibOrbisPkg/PKG/PkgBuilder.cs
@@ -376,10 +376,16 @@ namespace LibOrbisPkg.PKG
         pkg.ParamSfo,
         pkg.PsReservedDat
       });
-      foreach(var file in project.RootDir.Dirs.Where(f => f.name == "sce_sys").First().Files.Where(f => EntryNames.NameToId.ContainsKey(f.name)))
+      foreach(var file in project.RootDir.Dirs.Where(f => f.name == "sce_sys").First().GetAllChildrenFiles())
       {
         var name = file.name;
-        if (name == "param.sfo") continue;
+        var parent = file.Parent;
+        while (parent != null && parent != project.RootDir && parent.name != "sce_sys")
+        {
+          name = parent.name + "/" + name;
+          parent = parent.Parent;
+        }
+        if (!EntryNames.NameToId.ContainsKey(name) || name == "param.sfo") continue;
         var entry = new FileEntry(EntryNames.NameToId[name], file.Write, (uint)file.Size);
         pkg.Entries.Add(entry);
       }


### PR DESCRIPTION
This fixes the bug where files in `sce_sys`, e.g. `icon0.png`, `param.sfo`, get treated as entries correctly, however nested directories within `sce_sys` would not be (e.g. `sce_sys/changeinfo/changeinfo.xml` or `sce_sys/trophy/trophy00.trp`).

Fixes #8
