### PR TITLE
(Draft) feature: support generating patch packages

### DIFF
--- a/LibOrbisPkg/GP4/Gp4Validator.cs
+++ b/LibOrbisPkg/GP4/Gp4Validator.cs
@@ -93,6 +93,8 @@ namespace LibOrbisPkg.GP4
       {
         case VolumeType.pkg_ps4_app:
           break;
+        case VolumeType.pkg_ps4_patch:
+          break;
         case VolumeType.pkg_ps4_ac_data:
           break;
         case VolumeType.pkg_ps4_ac_nodata:

--- a/LibOrbisPkg/PKG/PkgBuilder.cs
+++ b/LibOrbisPkg/PKG/PkgBuilder.cs
@@ -309,8 +309,6 @@ namespace LibOrbisPkg.PKG
       pkg.Metas = new MetasEntry();
       pkg.Digests = new GenericEntry(EntryId.DIGESTS);
       pkg.EntryNames = new NameTableEntry();
-      pkg.LicenseDat = GenLicense();
-      pkg.LicenseInfo = new GenericEntry(EntryId.LICENSE_INFO) { FileData = GenLicenseInfo() };
       var paramSfoFile = project.RootDir.GetFile("sce_sys/param.sfo");
       if(paramSfoFile == null)
       {
@@ -369,10 +367,18 @@ namespace LibOrbisPkg.PKG
           pkg.ChunkXml
         });
       }
+      if (volType != GP4.VolumeType.pkg_ps4_patch)
+      {
+        pkg.LicenseDat = GenLicense();
+        pkg.LicenseInfo = new GenericEntry(EntryId.LICENSE_INFO) { FileData = GenLicenseInfo() };
+        pkg.Entries.AddRange(new Entry[]
+        {
+          pkg.LicenseDat,
+          pkg.LicenseInfo,
+        });
+      }
       pkg.Entries.AddRange(new Entry[]
-      { 
-        pkg.LicenseDat,
-        pkg.LicenseInfo,
+      {
         pkg.ParamSfo,
         pkg.PsReservedDat
       });
@@ -493,11 +499,9 @@ namespace LibOrbisPkg.PKG
       switch (t)
       {
         case GP4.VolumeType.pkg_ps4_app:
-          return ContentType.GD;
         case GP4.VolumeType.pkg_ps4_patch:
-          return ContentType.DP;
         case GP4.VolumeType.pkg_ps4_remaster:
-          return ContentType.DP;
+          return ContentType.GD;
         case GP4.VolumeType.pkg_ps4_ac_data:
         case GP4.VolumeType.pkg_ps4_sf_theme:
         case GP4.VolumeType.pkg_ps4_theme:
@@ -519,6 +523,8 @@ namespace LibOrbisPkg.PKG
         case GP4.VolumeType.pkg_ps4_theme:
           return ContentFlags.GD_AC;
         case GP4.VolumeType.pkg_ps4_patch:
+          // TODO
+          return ContentFlags.PATCHGO | ContentFlags.GD_AC | ContentFlags.CUMULATIVE_PATCH;
         case GP4.VolumeType.pkg_ps4_remaster:
           // TODO
           return ContentFlags.SUBSEQUENT_PATCH;

--- a/PkgEditor/Views/GP4View.Designer.cs
+++ b/PkgEditor/Views/GP4View.Designer.cs
@@ -266,7 +266,8 @@
       this.pkgTypeDropdown.Items.AddRange(new object[] {
             "Game Package",
             "Additional Content",
-            "Additional Content w/ No Data"});
+            "Additional Content w/ No Data",
+            "Game Patch Package"});
       this.pkgTypeDropdown.Location = new System.Drawing.Point(284, 16);
       this.pkgTypeDropdown.Name = "pkgTypeDropdown";
       this.pkgTypeDropdown.Size = new System.Drawing.Size(186, 21);

--- a/PkgEditor/Views/GP4View.cs
+++ b/PkgEditor/Views/GP4View.cs
@@ -73,6 +73,10 @@ namespace PkgEditor.Views
           pkgTypeDropdown.SelectedIndex = 2;
           entitlementKeyTextbox.Enabled = true;
           break;
+        case VolumeType.pkg_ps4_patch:
+          pkgTypeDropdown.SelectedIndex = 3;
+          entitlementKeyTextbox.Enabled = false;
+          break;
         default:
           break;
       }
@@ -242,7 +246,10 @@ namespace PkgEditor.Views
       var ofd = new SaveFileDialog();
       ofd.Filter = "PKG Image|*.pkg";
       ofd.Title = "Choose output path for PKG";
-      ofd.FileName = proj.volume.Package.ContentId + ".pkg";
+      if (proj.volume.Type == VolumeType.pkg_ps4_patch || proj.volume.Type == VolumeType.pkg_ps4_remaster)
+        ofd.FileName = proj.volume.Package.ContentId + "-patch.pkg"; // TODO: version from PARAM.SFO
+      else
+        ofd.FileName = proj.volume.Package.ContentId + ".pkg";
       if (ofd.ShowDialog() == DialogResult.OK)
       {
         var logBox = new LogWindow();
@@ -251,12 +258,13 @@ namespace PkgEditor.Views
         Action<string> LogLine = x => logBox.BeginInvoke(new Action(() => writer.WriteLine(x)));
         try
         {
-          await Task.Run(() => {
+          await Task.Run(() =>
+          {
             new PkgBuilder(PkgProperties.FromGp4(proj, Path.GetDirectoryName(path))).Write(ofd.FileName, LogLine);
             LogLine($"Saved to {ofd.FileName}");
           });
         }
-        catch(Exception ex)
+        catch (Exception ex)
         {
           writer.WriteLine("Error: " + ex);
           writer.WriteLine(ex.StackTrace);


### PR DESCRIPTION
Would be useful if a large homebrew (e.g. a game port) needs just a small executable or asset update.

Currently doesn't ask for a base package, and the general digests file doesn't get created properly (results in error CE-36433-9 when installing).

I believe the general digests generation code isn't too accurate, the way it gets parsed and created doesn't make sense when compared to files from legitimate packages. There isn't much documentation on the format either...